### PR TITLE
Release/2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.3.2
+* Fix documentation issue (Android version was missing a zero in all docs)
+* Dependency Updates
+  * WARDEN-roboto 1.7.1 (also fixing the same documentation issue)
+  * Kotlin 2.1.0
+  * Signum Indispensable 3.12.0
+  * Bouncy Castle 1.79
+
 ## 2.3.1
 * Fix wrong dependency
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-plugins {  id("at.asitplus.gradle.conventions") version "2.0.20+20240920" }
+plugins {  id("at.asitplus.gradle.conventions") version "2.1.0+20241204" }
 
 group = "at.asitplus"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 jdk.version=17
-artifactVersion=2.3.1
-androidAttestationVersion=1.7.0
+artifactVersion=2.3.2-SNAPSHOT
+androidAttestationVersion=1.7.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 jdk.version=17
-artifactVersion=2.3.2-SNAPSHOT
-androidAttestationVersion=1.7.1-SNAPSHOT
+artifactVersion=2.3.2
+androidAttestationVersion=1.7.1

--- a/warden/build.gradle.kts
+++ b/warden/build.gradle.kts
@@ -24,7 +24,7 @@ sourceSets.test {
 dependencies {
     api("at.asitplus:warden-roboto:$androidAttestationVersion")
     api(datetime())
-    implementation("at.asitplus.signum:indispensable:3.9.0")
+    implementation("at.asitplus.signum:indispensable:3.12.0")
     implementation("ch.veehait.devicecheck:devicecheck-appattest:0.9.6")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.14.2")
     implementation("net.swiftzer.semver:semver:1.2.0")


### PR DESCRIPTION
* Fix documentation issue (Android version was missing a zero in all docs)
* Dependency Updates
  * WARDEN-roboto 1.7.1 (also fixing the same documentation issue)
  * Kotlin 2.1.0
  * Signum Indispensable 3.12.0
  * Bouncy Castle 1.79